### PR TITLE
Change default ethereum RPC

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -2,5 +2,5 @@ log: info
 store: ~/.unchained
 name: Change me
 rpc:
-  ethereum: https://eth.llamarpc.com
+  ethereum: https://ethereum.publicnode.com
   avalanche_fuji: https://ava-testnet.public.blastapi.io/ext/bc/C/rpc


### PR DESCRIPTION
I changed the default Ethereum node RPC in conf.yaml to publicnode URL.